### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/samp-reston/doip-sockets/compare/v0.1.0...v0.2.0) - 2025-01-13
+
+### Added
+
+- finish documentation and api polishing
+- completed type safe UDP socket
+- add into split method
+- implements from_std for tcp
+- implement tcp only sending and generic reading
+
+### Fixed
+
+- remove dead code and add remainder of tcp compliant payloadtypes
+
+### Other
+
+- fix tests
+- update deps
+- *(api)* updated module exports
+- remove copies, add access to inner at ref
+- extract into better mod structure
+- added test for into_split()
+- remove more dead code
+- remove dead code
+- improve send to only send applicable tcp types
+
 ## [0.1.0](https://github.com/samp-reston/doip-sockets/releases/tag/v0.1.0) - 2025-01-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-sockets"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) implementation for TCP & UDP Sockets with helper functions."


### PR DESCRIPTION
## 🤖 New release
* `doip-sockets`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `doip-sockets` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct doip_sockets::TcpStream, previously in file C:\Users\sampr\AppData\Local\Temp\.tmpA9Lg9k\doip-sockets\src\tcp.rs:10
  struct doip_sockets::UdpSocket, previously in file C:\Users\sampr\AppData\Local\Temp\.tmpA9Lg9k\doip-sockets\src\udp.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/samp-reston/doip-sockets/compare/v0.1.0...v0.2.0) - 2025-01-13

### Added

- finish documentation and api polishing
- completed type safe UDP socket
- add into split method
- implements from_std for tcp
- implement tcp only sending and generic reading

### Fixed

- remove dead code and add remainder of tcp compliant payloadtypes

### Other

- fix tests
- update deps
- *(api)* updated module exports
- remove copies, add access to inner at ref
- extract into better mod structure
- added test for into_split()
- remove more dead code
- remove dead code
- improve send to only send applicable tcp types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).