### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/samp-reston/doip-sockets/compare/v0.2.3...v0.2.4) - 2025-01-14
+
+### Added
+
+- added helper method to access listener and socket inner
+
 ## [0.2.3](https://github.com/samp-reston/doip-sockets/compare/v0.2.2...v0.2.3) - 2025-01-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-sockets"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) implementation for TCP & UDP Sockets with helper functions."


### PR DESCRIPTION
## 🤖 New release
* `doip-sockets`: 0.2.3 -> 0.2.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/samp-reston/doip-sockets/compare/v0.2.3...v0.2.4) - 2025-01-14

### Added

- added helper method to access listener and socket inner
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).