### PR TITLE
Add SSL support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "fd972ae" }
+doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "f6bbc3b" }
 doip-definitions = { git = "https://github.com/theswiftfox/doip-definitions.git", rev = "6cd6d45" }
 futures = "0.3"
 tokio = { version = "1.43.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "d447035" }
-doip-definitions = { git = "https://github.com/theswiftfox/doip-definitions.git", rev = "398c1bd" }
-futures = "0.3"
+doip-codec = "2.0.8"
+doip-definitions = "3.0.12"
+futures = "0.3.31"
 tokio = { version = "1.43.0", features = [
   "rt-multi-thread",
   "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-doip-codec = "2.0.2"
-doip-definitions = "1.0.3"
-futures = "0.3.31"
+doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "fd972ae" }
+doip-definitions = { git = "https://github.com/theswiftfox/doip-definitions.git", rev = "6cd6d45" }
+futures = "0.3"
 tokio = { version = "1.43.0", features = [
   "rt-multi-thread",
   "macros",
@@ -28,6 +28,6 @@ tokio = { version = "1.43.0", features = [
 tokio-util = { version = "0.7.13", features = ["codec", "net"] }
 tokio-openssl = "0.6.5"
 openssl = "0.10.70"
-thiserror = "2.0.11"
+thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "a01d349" }
-doip-definitions = { git = "https://github.com/theswiftfox/doip-definitions.git", rev = "6cd6d45" }
+doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "d447035" }
+doip-definitions = { git = "https://github.com/theswiftfox/doip-definitions.git", rev = "398c1bd" }
 futures = "0.3"
 tokio = { version = "1.43.0", features = [
   "rt-multi-thread",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codegen-units = 1
 
 [dependencies]
 doip-codec = "2.0.8"
-doip-definitions = "3.0.12"
+doip-definitions = "3.0.13"
 futures = "0.3.31"
 tokio = { version = "1.43.0", features = [
   "rt-multi-thread",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "f6bbc3b" }
+doip-codec = { git = "https://github.com/theswiftfox/doip-codec.git", rev = "a01d349" }
 doip-definitions = { git = "https://github.com/theswiftfox/doip-definitions.git", rev = "6cd6d45" }
 futures = "0.3"
 tokio = { version = "1.43.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ tokio = { version = "1.43.0", features = [
   "io-util",
 ] }
 tokio-util = { version = "0.7.13", features = ["codec", "net"] }
+tokio-openssl = "0.6.5"
+openssl = "0.10.70"
 thiserror = "2.0.11"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,12 @@ tokio = { version = "1.43.0", features = [
   "io-util",
 ] }
 tokio-util = { version = "0.7.13", features = ["codec", "net"] }
-tokio-openssl = "0.6.5"
-openssl = "0.10.70"
+tokio-openssl = { version = "0.6.5", optional = true }
+openssl = { version = "0.10.70", optional = true }
 thiserror = "2.0.12"
 
 [dev-dependencies]
+
+[features]
+default = []
+ssl = ["dep:tokio-openssl", "dep:openssl"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 pub enum SocketSendError {
     /// Encode error from Codec
     #[error("Underlying Codec Error: {0}")]
-    EncodeError(#[from] doip_codec::EncodeError),
+    EncodeError(doip_codec::Error),
 
     /// Payload Type not supported by TCP Socket
     #[error("Payload Type not supported by TCP Socket")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,7 @@ pub mod tcp;
 /// Simple UDP Socket implementation for UDP communication.
 pub mod udp;
 
-pub use doip_codec::DecodeError;
-pub use doip_codec::EncodeError;
+pub use doip_codec::Error;
 
 /// Configuration for UDP and TCP Sockets
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ pub mod tcp;
 /// Simple UDP Socket implementation for UDP communication.
 pub mod udp;
 
+pub use doip_codec::DecodeError;
+pub use doip_codec::EncodeError;
+
 /// Configuration for UDP and TCP Sockets
 ///
 /// This provides the methods within each struct with constants which can be set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,15 @@
 //! currently of which is solely limited to the version of the protocol used,
 //! however can be extended in future version.
 
-use doip_definitions::header::DoipVersion;
+use doip_definitions::{
+    header::{DoipHeader, PayloadType, ProtocolVersion},
+    payload::{
+        AliveCheckResponse, DiagnosticMessageAck, DiagnosticMessageNack, DoipPayload,
+        EntityStatusRequest, GenericNack, PowerInformationResponse, RoutingActivationRequest,
+        RoutingActivationResponse, VehicleAnnouncementMessage, VehicleIdentificationRequestEid,
+        VehicleIdentificationRequestVin,
+    },
+};
 mod error;
 
 /// Simple TCP Stream and Split implentation for a TCP Stream allowing the conversion of a
@@ -31,5 +39,70 @@ pub mod udp;
 /// during a typical usage with DoIP such as the protocol_version.
 #[derive(Debug, Copy, Clone)]
 pub struct SocketConfig {
-    protocol_version: DoipVersion,
+    protocol_version: ProtocolVersion,
+}
+
+pub(crate) fn new_header(protocol_version: ProtocolVersion, payload: &DoipPayload) -> DoipHeader {
+    let (payload_length, payload_type) = match payload {
+        DoipPayload::GenericNack(_) => (size_of::<GenericNack>(), PayloadType::GenericNack),
+        DoipPayload::VehicleIdentificationRequest(_) => {
+            (0, PayloadType::VehicleIdentificationRequest)
+        }
+        DoipPayload::VehicleIdentificationRequestEid(_) => (
+            size_of::<VehicleIdentificationRequestEid>(),
+            PayloadType::VehicleIdentificationRequestEid,
+        ),
+        DoipPayload::VehicleIdentificationRequestVin(_) => (
+            size_of::<VehicleIdentificationRequestVin>(),
+            PayloadType::VehicleIdentificationRequestVin,
+        ),
+        DoipPayload::VehicleAnnouncementMessage(_) => (
+            size_of::<VehicleAnnouncementMessage>(),
+            PayloadType::VehicleAnnouncementMessage,
+        ),
+        DoipPayload::RoutingActivationRequest(_) => (
+            size_of::<RoutingActivationRequest>(),
+            PayloadType::RoutingActivationRequest,
+        ),
+        DoipPayload::RoutingActivationResponse(_) => (
+            size_of::<RoutingActivationResponse>(),
+            PayloadType::RoutingActivationResponse,
+        ),
+        DoipPayload::AliveCheckRequest(_) => (0, PayloadType::AliveCheckRequest),
+        DoipPayload::AliveCheckResponse(_) => (
+            size_of::<AliveCheckResponse>(),
+            PayloadType::AliveCheckResponse,
+        ),
+        DoipPayload::EntityStatusRequest(_) => (
+            size_of::<EntityStatusRequest>(),
+            PayloadType::EntityStatusRequest,
+        ),
+        DoipPayload::EntityStatusResponse(_) => (0, PayloadType::EntityStatusResponse),
+        DoipPayload::PowerInformationRequest(_) => (0, PayloadType::PowerInformationRequest),
+        DoipPayload::PowerInformationResponse(_) => (
+            size_of::<PowerInformationResponse>(),
+            PayloadType::PowerInformationResponse,
+        ),
+        DoipPayload::DiagnosticMessage(msg) => (
+            msg.source_address.len() + msg.target_address.len() + msg.message.len(),
+            PayloadType::DiagnosticMessage,
+        ),
+        DoipPayload::DiagnosticMessageAck(_) => (
+            size_of::<DiagnosticMessageAck>(),
+            PayloadType::DiagnosticMessageAck,
+        ),
+        DoipPayload::DiagnosticMessageNack(_) => (
+            size_of::<DiagnosticMessageNack>(),
+            PayloadType::DiagnosticMessageNack,
+        ),
+    };
+
+    let inverse_protocol_version = !(protocol_version as u8);
+
+    DoipHeader {
+        protocol_version,
+        inverse_protocol_version,
+        payload_type,
+        payload_length: payload_length as u32,
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,15 +14,7 @@
 //! currently of which is solely limited to the version of the protocol used,
 //! however can be extended in future version.
 
-use doip_definitions::{
-    header::{DoipHeader, PayloadType, ProtocolVersion},
-    payload::{
-        AliveCheckResponse, DiagnosticMessageAck, DiagnosticMessageNack, DoipPayload,
-        EntityStatusRequest, GenericNack, PowerInformationResponse, RoutingActivationRequest,
-        RoutingActivationResponse, VehicleAnnouncementMessage, VehicleIdentificationRequestEid,
-        VehicleIdentificationRequestVin,
-    },
-};
+use doip_definitions::header::ProtocolVersion;
 mod error;
 
 /// Simple TCP Stream and Split implentation for a TCP Stream allowing the conversion of a
@@ -42,69 +34,4 @@ pub use doip_codec::Error;
 #[derive(Debug, Copy, Clone)]
 pub struct SocketConfig {
     protocol_version: ProtocolVersion,
-}
-
-pub(crate) fn new_header(protocol_version: ProtocolVersion, payload: &DoipPayload) -> DoipHeader {
-    let (payload_length, payload_type) = match payload {
-        DoipPayload::GenericNack(_) => (size_of::<GenericNack>(), PayloadType::GenericNack),
-        DoipPayload::VehicleIdentificationRequest(_) => {
-            (0, PayloadType::VehicleIdentificationRequest)
-        }
-        DoipPayload::VehicleIdentificationRequestEid(_) => (
-            size_of::<VehicleIdentificationRequestEid>(),
-            PayloadType::VehicleIdentificationRequestEid,
-        ),
-        DoipPayload::VehicleIdentificationRequestVin(_) => (
-            size_of::<VehicleIdentificationRequestVin>(),
-            PayloadType::VehicleIdentificationRequestVin,
-        ),
-        DoipPayload::VehicleAnnouncementMessage(_) => (
-            size_of::<VehicleAnnouncementMessage>(),
-            PayloadType::VehicleAnnouncementMessage,
-        ),
-        DoipPayload::RoutingActivationRequest(_) => (
-            size_of::<RoutingActivationRequest>(),
-            PayloadType::RoutingActivationRequest,
-        ),
-        DoipPayload::RoutingActivationResponse(_) => (
-            size_of::<RoutingActivationResponse>(),
-            PayloadType::RoutingActivationResponse,
-        ),
-        DoipPayload::AliveCheckRequest(_) => (0, PayloadType::AliveCheckRequest),
-        DoipPayload::AliveCheckResponse(_) => (
-            size_of::<AliveCheckResponse>(),
-            PayloadType::AliveCheckResponse,
-        ),
-        DoipPayload::EntityStatusRequest(_) => (
-            size_of::<EntityStatusRequest>(),
-            PayloadType::EntityStatusRequest,
-        ),
-        DoipPayload::EntityStatusResponse(_) => (0, PayloadType::EntityStatusResponse),
-        DoipPayload::PowerInformationRequest(_) => (0, PayloadType::PowerInformationRequest),
-        DoipPayload::PowerInformationResponse(_) => (
-            size_of::<PowerInformationResponse>(),
-            PayloadType::PowerInformationResponse,
-        ),
-        DoipPayload::DiagnosticMessage(msg) => (
-            msg.source_address.len() + msg.target_address.len() + msg.message.len(),
-            PayloadType::DiagnosticMessage,
-        ),
-        DoipPayload::DiagnosticMessageAck(_) => (
-            size_of::<DiagnosticMessageAck>(),
-            PayloadType::DiagnosticMessageAck,
-        ),
-        DoipPayload::DiagnosticMessageNack(_) => (
-            size_of::<DiagnosticMessageNack>(),
-            PayloadType::DiagnosticMessageNack,
-        ),
-    };
-
-    let inverse_protocol_version = !(protocol_version as u8);
-
-    DoipHeader {
-        protocol_version,
-        inverse_protocol_version,
-        payload_type,
-        payload_length: payload_length as u32,
-    }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -8,11 +8,13 @@ use doip_definitions::{
 
 use crate::SocketConfig;
 
+#[cfg(feature = "ssl")]
 mod ssl_stream;
 mod tcp_listener;
 mod tcp_socket;
 mod tcp_split;
 mod tcp_stream;
+#[cfg(feature = "ssl")]
 pub use crate::tcp::ssl_stream::*;
 pub use crate::tcp::tcp_listener::*;
 pub use crate::tcp::tcp_socket::*;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,6 +1,6 @@
 use doip_definitions::{
-    header::DoipVersion,
-    message::{
+    header::ProtocolVersion,
+    payload::{
         AliveCheckRequest, AliveCheckResponse, DiagnosticMessage, DiagnosticMessageAck,
         DiagnosticMessageNack, GenericNack, RoutingActivationRequest, RoutingActivationResponse,
     },
@@ -35,7 +35,7 @@ impl DoipTcpPayload for DiagnosticMessageNack {}
 impl Default for SocketConfig {
     fn default() -> Self {
         Self {
-            protocol_version: DoipVersion::DefaultValue,
+            protocol_version: ProtocolVersion::DefaultValue,
         }
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -8,14 +8,16 @@ use doip_definitions::{
 
 use crate::SocketConfig;
 
+mod ssl_stream;
+mod tcp_listener;
+mod tcp_socket;
 mod tcp_split;
 mod tcp_stream;
-mod tcp_socket;
-mod tcp_listener;
+pub use crate::tcp::ssl_stream::*;
+pub use crate::tcp::tcp_listener::*;
+pub use crate::tcp::tcp_socket::*;
 pub use crate::tcp::tcp_split::*;
 pub use crate::tcp::tcp_stream::*;
-pub use crate::tcp::tcp_socket::*;
-pub use crate::tcp::tcp_listener::*;
 
 /// Helper Trait which assists in applying LSP hints to the send and receive of
 /// sockets.

--- a/src/tcp/ssl_stream.rs
+++ b/src/tcp/ssl_stream.rs
@@ -10,10 +10,7 @@ use doip_definitions::{
 };
 use futures::{SinkExt, StreamExt};
 use openssl::ssl::{SslConnector, SslMethod, SslOptions, SslVerifyMode, SslVersion};
-use tokio::{
-    io::AsyncWriteExt,
-    net::{TcpStream as TokioTcpStream, ToSocketAddrs},
-};
+use tokio::net::{TcpStream as TokioTcpStream, ToSocketAddrs};
 
 use tokio_openssl::SslStream;
 use tokio_util::codec::{Framed, FramedRead, FramedWrite};
@@ -69,9 +66,11 @@ impl DoIpSslStream {
                 let ssl = connect_configuration.into_ssl("domain")?;
                 let mut stream = SslStream::new(ssl, stream)?;
 
-                // wait for the actual connection ...
-                // TODO: proper error handling
-                Pin::new(&mut stream).connect().await.unwrap();
+                // wait for the actual connection .
+                Pin::new(&mut stream)
+                    .connect()
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
                 Ok(Self::apply_codec(stream))
             }

--- a/src/tcp/ssl_stream.rs
+++ b/src/tcp/ssl_stream.rs
@@ -79,8 +79,9 @@ impl DoIpSslStream {
                     preset_options.union(SslOptions::ALLOW_UNSAFE_LEGACY_RENEGOTIATION),
                 );
 
-                let connect_configuration = builder.build().configure()?;
-                let ssl = connect_configuration.into_ssl("domain")?;
+                let mut connect_configuration = builder.build().configure()?;
+                connect_configuration.set_use_server_name_indication(false);
+                let ssl = connect_configuration.into_ssl("")?;
                 let mut stream = SslStream::new(ssl, stream)?;
 
                 // wait for the actual connection .

--- a/src/tcp/ssl_stream.rs
+++ b/src/tcp/ssl_stream.rs
@@ -49,7 +49,14 @@ impl DoIpSslStream {
             Ok(stream) => {
                 // allow unsafe ciphers in order to get better debugging
                 let mut builder = SslConnector::builder(SslMethod::tls())?;
-                builder.set_cipher_list("ECDHE-ECDSA-NULL-SHA")?;
+                let tls_ciphers = vec![
+                    "AES-256-GCM-SHA384",
+                    "CHACHA20-POLY1305-SHA256",
+                    "ECDHE-RSA-AES256-GCM-SHA384",
+                    "ECDHE-ECDSA-AES256-GCM-SHA384",
+                    "ECDHE-ECDSA-NULL-SHA",
+                ];
+                builder.set_cipher_list(&tls_ciphers.join(":"))?;
                 builder.set_verify(SslVerifyMode::NONE);
                 // necessary for NULL encryption
                 builder.set_security_level(0);
@@ -144,7 +151,6 @@ mod test_tcp_stream {
             ActivationCode, ActivationType, RoutingActivationRequest, RoutingActivationResponse,
         },
     };
-    use tokio::io::AsyncReadExt;
 
     use crate::tcp::{ssl_stream::DoIpSslStream, tcp_stream::TcpStream};
 

--- a/src/tcp/ssl_stream.rs
+++ b/src/tcp/ssl_stream.rs
@@ -3,7 +3,7 @@ use std::{
     pin::Pin,
 };
 
-use doip_codec::{DecodeError, DoipCodec};
+use doip_codec::{DoipCodec, Error as CodecError};
 use doip_definitions::{header::ProtocolVersion, message::DoipMessage, payload::DoipPayload};
 use futures::{SinkExt, StreamExt};
 use openssl::ssl::{Ssl, SslContextBuilder, SslMethod, SslOptions, SslVerifyMode, SslVersion};
@@ -121,7 +121,7 @@ impl DoIpSslStream {
     }
 
     /// Read a DoIP frame off the stream
-    pub async fn read(&mut self) -> Option<Result<DoipMessage, DecodeError>> {
+    pub async fn read(&mut self) -> Option<Result<DoipMessage, CodecError>> {
         self.io.next().await
     }
 

--- a/src/tcp/tcp_split.rs
+++ b/src/tcp/tcp_split.rs
@@ -1,4 +1,4 @@
-use doip_codec::{DecodeError, DoipCodec};
+use doip_codec::{DoipCodec, Error as CodecError};
 use doip_definitions::{message::DoipMessage, payload::DoipPayload};
 use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
@@ -35,7 +35,7 @@ where
     }
 
     /// Read from the stream
-    pub async fn read(&mut self) -> Option<Result<DoipMessage, DecodeError>> {
+    pub async fn read(&mut self) -> Option<Result<DoipMessage, CodecError>> {
         self.io.next().await
     }
 }

--- a/src/tcp/tcp_split.rs
+++ b/src/tcp/tcp_split.rs
@@ -1,10 +1,10 @@
 use doip_codec::{DoipCodec, Error as CodecError};
-use doip_definitions::{message::DoipMessage, payload::DoipPayload};
+use doip_definitions::{builder::DoipMessageBuilder, message::DoipMessage, payload::DoipPayload};
 use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
 use tokio_util::codec::{FramedRead, FramedWrite};
 
-use crate::{error::SocketSendError, new_header};
+use crate::error::SocketSendError;
 
 use super::SocketConfig;
 
@@ -67,10 +67,10 @@ where
 
     /// Send a message to the sink
     pub async fn send(&mut self, payload: DoipPayload) -> Result<(), SocketSendError> {
-        let msg = DoipMessage {
-            header: new_header(self.config.protocol_version, &payload),
-            payload,
-        };
+        let msg = DoipMessageBuilder::new()
+            .protocol_version(self.config.protocol_version)
+            .payload(payload)
+            .build();
 
         match self.io.send(msg).await {
             Ok(_) => Ok(()),

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,4 +1,4 @@
-use doip_definitions::message::{
+use doip_definitions::payload::{
     EntityStatusRequest, EntityStatusResponse, GenericNack, PowerInformationRequest,
     PowerInformationResponse, VehicleAnnouncementMessage, VehicleIdentificationRequest,
     VehicleIdentificationRequestEid, VehicleIdentificationRequestVin,

--- a/src/udp/udp_socket.rs
+++ b/src/udp/udp_socket.rs
@@ -21,6 +21,17 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
+    /// Creates a new UDP Socket from an `std::net::UdpSocket`
+    /// This can be used in conjunction with `socket2`’s `Socket`` interface to configure a socket before it’s handed off, such as setting options like `reuse_address`
+    pub fn from_std(sock: std::net::UdpSocket) -> io::Result<UdpSocket> {
+        let sock = TokioUdpSocket::from_std(sock)?;
+
+        Ok(UdpSocket {
+            io: UdpFramed::new(sock, DoipCodec),
+            config: SocketConfig::default(),
+        })
+    }
+
     /// Bind the socket to a local address
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<UdpSocket> {
         let sock = TokioUdpSocket::bind(addr).await?;

--- a/src/udp/udp_socket.rs
+++ b/src/udp/udp_socket.rs
@@ -1,6 +1,9 @@
-use crate::{new_header, SocketConfig};
+use crate::SocketConfig;
 use doip_codec::{DoipCodec, Error as CodecError};
-use doip_definitions::{header::ProtocolVersion, message::DoipMessage, payload::DoipPayload};
+use doip_definitions::{
+    builder::DoipMessageBuilder, header::ProtocolVersion, message::DoipMessage,
+    payload::DoipPayload,
+};
 use futures::{SinkExt, StreamExt};
 use std::{io, net::SocketAddr};
 use tokio::net::{ToSocketAddrs, UdpSocket as TokioUdpSocket};
@@ -50,10 +53,10 @@ impl UdpSocket {
 
     /// Send a DoIP Frame
     pub async fn send(&mut self, payload: DoipPayload, addr: SocketAddr) -> Result<(), CodecError> {
-        let msg = DoipMessage {
-            header: new_header(self.config.protocol_version, &payload),
-            payload,
-        };
+        let msg = DoipMessageBuilder::new()
+            .protocol_version(self.config.protocol_version)
+            .payload(payload)
+            .build();
         self.io.send((msg, addr)).await
     }
 

--- a/src/udp/udp_socket.rs
+++ b/src/udp/udp_socket.rs
@@ -1,5 +1,5 @@
 use crate::{new_header, SocketConfig};
-use doip_codec::{DecodeError, DoipCodec, EncodeError};
+use doip_codec::{DoipCodec, Error as CodecError};
 use doip_definitions::{header::ProtocolVersion, message::DoipMessage, payload::DoipPayload};
 use futures::{SinkExt, StreamExt};
 use std::{io, net::SocketAddr};
@@ -44,16 +44,12 @@ impl UdpSocket {
     }
 
     /// Receive a DoIP Frame from the socket queue
-    pub async fn recv(&mut self) -> Option<Result<(DoipMessage, SocketAddr), DecodeError>> {
+    pub async fn recv(&mut self) -> Option<Result<(DoipMessage, SocketAddr), CodecError>> {
         self.io.next().await
     }
 
     /// Send a DoIP Frame
-    pub async fn send(
-        &mut self,
-        payload: DoipPayload,
-        addr: SocketAddr,
-    ) -> Result<(), EncodeError> {
+    pub async fn send(&mut self, payload: DoipPayload, addr: SocketAddr) -> Result<(), CodecError> {
         let msg = DoipMessage {
             header: new_header(self.config.protocol_version, &payload),
             payload,


### PR DESCRIPTION
This PR depends on https://github.com/samp-reston/doip-definitions/pull/29 and https://github.com/samp-reston/doip-codec/pull/11.

It adds support for establishing an SSL connection to ECUs. The configuration of the SSL context has some defaults, but the user can provide different / additional ciphers and eliptic-curve-groups.  

Additionally the PR has a few changes due to the newer versions of doip-definitions and doip-codec used here.

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com) on behalf of Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

